### PR TITLE
feat: add context-related models and CRUD helpers

### DIFF
--- a/app/memory/crud.py
+++ b/app/memory/crud.py
@@ -6,7 +6,17 @@ from typing import Dict, List, Optional
 
 from sqlmodel import select
 
-from app.models.souvenir import EmoLvl2ToLv1, Link, LinkSouvenir, Souvenir
+from app.models.souvenir import (
+    BackgroundThought,
+    Context,
+    EmoLvl2ToLv1,
+    Fragment,
+    Link,
+    LinkSouvenir,
+    Souvenir,
+    User,
+    WorkingMemory,
+)
 from app.memory.db import get_session
 
 
@@ -194,4 +204,281 @@ def obtenir_links_pour_souvenir(mem_id: int) -> List[Link]:
             .where(LinkSouvenir.mem_id == mem_id)
         )
         return list(session.exec(statement))
+
+
+# ----- CRUD pour les fragments -----
+
+def creer_fragment(fragment: Fragment) -> Fragment:
+    """Persiste un nouveau fragment."""
+    with get_session() as session:
+        session.add(fragment)
+        session.commit()
+        session.refresh(fragment)
+        return fragment
+
+
+def obtenir_fragment(fragment_id: int) -> Optional[Fragment]:
+    """Récupère un fragment par son identifiant."""
+    with get_session() as session:
+        return session.get(Fragment, fragment_id)
+
+
+def chercher_fragments(limit: int = 10) -> List[Fragment]:
+    """Retourne les fragments les plus récents."""
+    with get_session() as session:
+        statement = (
+            select(Fragment)
+            .order_by(Fragment.created_at.desc())
+            .limit(limit)
+        )
+        return list(session.exec(statement))
+
+
+def mettre_a_jour_fragment(
+    fragment_id: int, data: Dict
+) -> Optional[Fragment]:
+    """Met à jour les champs d'un fragment."""
+    with get_session() as session:
+        fragment = session.get(Fragment, fragment_id)
+        if not fragment:
+            return None
+        for key, value in data.items():
+            setattr(fragment, key, value)
+        session.add(fragment)
+        session.commit()
+        session.refresh(fragment)
+        return fragment
+
+
+def supprimer_fragment(fragment_id: int) -> bool:
+    """Supprime un fragment."""
+    with get_session() as session:
+        fragment = session.get(Fragment, fragment_id)
+        if not fragment:
+            return False
+        session.delete(fragment)
+        session.commit()
+        return True
+
+
+# ----- CRUD pour les contextes -----
+
+def creer_context(context: Context) -> Context:
+    """Persiste un nouveau contexte."""
+    with get_session() as session:
+        session.add(context)
+        session.commit()
+        session.refresh(context)
+        return context
+
+
+def obtenir_context(context_id: int) -> Optional[Context]:
+    """Récupère un contexte par son identifiant."""
+    with get_session() as session:
+        return session.get(Context, context_id)
+
+
+def chercher_contexts(limit: int = 10) -> List[Context]:
+    """Retourne les contextes les plus récents."""
+    with get_session() as session:
+        statement = (
+            select(Context)
+            .order_by(Context.created_at.desc())
+            .limit(limit)
+        )
+        return list(session.exec(statement))
+
+
+def mettre_a_jour_context(
+    context_id: int, data: Dict
+) -> Optional[Context]:
+    """Met à jour un contexte existant."""
+    with get_session() as session:
+        context = session.get(Context, context_id)
+        if not context:
+            return None
+        for key, value in data.items():
+            setattr(context, key, value)
+        session.add(context)
+        session.commit()
+        session.refresh(context)
+        return context
+
+
+def supprimer_context(context_id: int) -> bool:
+    """Supprime un contexte."""
+    with get_session() as session:
+        context = session.get(Context, context_id)
+        if not context:
+            return False
+        session.delete(context)
+        session.commit()
+        return True
+
+
+# ----- CRUD pour les pensées de fond -----
+
+def creer_background_thought(
+    thought: BackgroundThought,
+) -> BackgroundThought:
+    """Persiste une nouvelle pensée de fond."""
+    with get_session() as session:
+        session.add(thought)
+        session.commit()
+        session.refresh(thought)
+        return thought
+
+
+def obtenir_background_thought(
+    thought_id: int,
+) -> Optional[BackgroundThought]:
+    """Récupère une pensée de fond via son identifiant."""
+    with get_session() as session:
+        return session.get(BackgroundThought, thought_id)
+
+
+def chercher_background_thoughts(
+    limit: int = 10,
+) -> List[BackgroundThought]:
+    """Retourne les pensées de fond les plus récentes."""
+    with get_session() as session:
+        statement = (
+            select(BackgroundThought)
+            .order_by(BackgroundThought.created_at.desc())
+            .limit(limit)
+        )
+        return list(session.exec(statement))
+
+
+def mettre_a_jour_background_thought(
+    thought_id: int, data: Dict
+) -> Optional[BackgroundThought]:
+    """Met à jour une pensée de fond."""
+    with get_session() as session:
+        thought = session.get(BackgroundThought, thought_id)
+        if not thought:
+            return None
+        for key, value in data.items():
+            setattr(thought, key, value)
+        session.add(thought)
+        session.commit()
+        session.refresh(thought)
+        return thought
+
+
+def supprimer_background_thought(thought_id: int) -> bool:
+    """Supprime une pensée de fond."""
+    with get_session() as session:
+        thought = session.get(BackgroundThought, thought_id)
+        if not thought:
+            return False
+        session.delete(thought)
+        session.commit()
+        return True
+
+
+# ----- CRUD pour la mémoire de travail -----
+
+def creer_working_memory(entry: WorkingMemory) -> WorkingMemory:
+    """Persiste une nouvelle entrée de mémoire de travail."""
+    with get_session() as session:
+        session.add(entry)
+        session.commit()
+        session.refresh(entry)
+        return entry
+
+
+def obtenir_working_memory(
+    working_memory_id: int,
+) -> Optional[WorkingMemory]:
+    """Récupère une entrée de mémoire de travail."""
+    with get_session() as session:
+        return session.get(WorkingMemory, working_memory_id)
+
+
+def chercher_working_memories(limit: int = 10) -> List[WorkingMemory]:
+    """Retourne les entrées de mémoire de travail récentes."""
+    with get_session() as session:
+        statement = (
+            select(WorkingMemory)
+            .order_by(WorkingMemory.created_at.desc())
+            .limit(limit)
+        )
+        return list(session.exec(statement))
+
+
+def mettre_a_jour_working_memory(
+    working_memory_id: int, data: Dict
+) -> Optional[WorkingMemory]:
+    """Met à jour une entrée de mémoire de travail."""
+    with get_session() as session:
+        working_memory = session.get(WorkingMemory, working_memory_id)
+        if not working_memory:
+            return None
+        for key, value in data.items():
+            setattr(working_memory, key, value)
+        session.add(working_memory)
+        session.commit()
+        session.refresh(working_memory)
+        return working_memory
+
+
+def supprimer_working_memory(working_memory_id: int) -> bool:
+    """Supprime une entrée de mémoire de travail."""
+    with get_session() as session:
+        working_memory = session.get(WorkingMemory, working_memory_id)
+        if not working_memory:
+            return False
+        session.delete(working_memory)
+        session.commit()
+        return True
+
+
+# ----- CRUD pour les utilisateurs -----
+
+def creer_user(user: User) -> User:
+    """Persiste un nouvel utilisateur."""
+    with get_session() as session:
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return user
+
+
+def obtenir_user(user_id: int) -> Optional[User]:
+    """Récupère un utilisateur via son identifiant."""
+    with get_session() as session:
+        return session.get(User, user_id)
+
+
+def chercher_users(limit: int = 10) -> List[User]:
+    """Retourne les utilisateurs triés par nom."""
+    with get_session() as session:
+        statement = select(User).order_by(User.username).limit(limit)
+        return list(session.exec(statement))
+
+
+def mettre_a_jour_user(user_id: int, data: Dict) -> Optional[User]:
+    """Met à jour les informations d'un utilisateur."""
+    with get_session() as session:
+        user = session.get(User, user_id)
+        if not user:
+            return None
+        for key, value in data.items():
+            setattr(user, key, value)
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return user
+
+
+def supprimer_user(user_id: int) -> bool:
+    """Supprime un utilisateur."""
+    with get_session() as session:
+        user = session.get(User, user_id)
+        if not user:
+            return False
+        session.delete(user)
+        session.commit()
+        return True
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,26 @@
 """Simplified exports for model package."""
 
-from .souvenir import Link, LinkSouvenir, Souvenir
+from .souvenir import (
+    BackgroundThought,
+    Context,
+    EmoLvl2ToLv1,
+    Fragment,
+    Link,
+    LinkSouvenir,
+    Souvenir,
+    User,
+    WorkingMemory,
+)
 
-__all__ = ["Souvenir", "Link", "LinkSouvenir"]
+__all__ = [
+    "Souvenir",
+    "Link",
+    "LinkSouvenir",
+    "EmoLvl2ToLv1",
+    "Fragment",
+    "Context",
+    "BackgroundThought",
+    "WorkingMemory",
+    "User",
+]
 

--- a/app/models/souvenir.py
+++ b/app/models/souvenir.py
@@ -74,3 +74,54 @@ class EmoLvl2ToLv1(SQLModel, table=True):
     anger: int = 0
     anticipation: int = 0
 
+
+class Fragment(SQLModel, table=True):
+    """Fragment textuel conservé pour enrichir les contextes générés."""
+
+    fragment_id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    content: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    user_id: Optional[int] = Field(default=None, foreign_key="user.user_id")
+
+
+class Context(SQLModel, table=True):
+    """Historique de contextes construits à partir de fragments."""
+
+    context_id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    description: str = ""
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    user_id: Optional[int] = Field(default=None, foreign_key="user.user_id")
+
+
+class BackgroundThought(SQLModel, table=True):
+    """Réflexions de fond générées pour un contexte donné."""
+
+    thought_id: Optional[int] = Field(default=None, primary_key=True)
+    context_id: Optional[int] = Field(default=None, foreign_key="context.context_id")
+    content: str
+    confidence: float = 0.0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class WorkingMemory(SQLModel, table=True):
+    """Éléments temporaires mis en avant pendant le raisonnement."""
+
+    working_memory_id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: Optional[int] = Field(default=None, foreign_key="user.user_id")
+    fragment_id: Optional[int] = Field(default=None, foreign_key="fragment.fragment_id")
+    state: str
+    expires_at: Optional[datetime] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class User(SQLModel, table=True):
+    """Profil utilisateur associé aux souvenirs et aux fragments."""
+
+    user_id: Optional[int] = Field(default=None, primary_key=True)
+    username: str
+    display_name: Optional[str] = None
+    email: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+


### PR DESCRIPTION
## Summary
- define SQLModel tables for fragments, contexts, background thoughts, working memory entries, and users
- expose the new models through the package init for convenient imports
- implement full CRUD helpers for each new table alongside existing memory utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc53b756bc8332aed5b78264df2d9c